### PR TITLE
v1.0.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-types-stream",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -24,6 +24,12 @@
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@types/cli-color/-/cli-color-0.3.29.tgz",
       "integrity": "sha1-yDpx/gLIx+HM7ASN1qJFjR9sluo=",
+      "dev": true
+    },
+    "@types/debug": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
+      "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==",
       "dev": true
     },
     "@types/faker": {
@@ -381,12 +387,12 @@
       "dev": true
     },
     "debug": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
-        "ms": "0.7.1"
+        "ms": "2.0.0"
       }
     },
     "deep-eql": {
@@ -775,6 +781,23 @@
         "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
         "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        }
       }
     },
     "moment": {
@@ -784,9 +807,9 @@
       "dev": true
     },
     "ms": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "nopt": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-types-stream",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.1",
   "description": "DynamoDB Stream Framework",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-types-stream",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "DynamoDB Stream Framework",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",
@@ -21,12 +21,14 @@
     "@types/chai": "3.4.34",
     "@types/chai-as-promised": "0.0.29",
     "@types/cli-color": "0.3.29",
+    "@types/debug": "0.0.30",
     "@types/faker": "^4.1.0",
     "@types/mocha": "2.2.32",
     "@types/node": "6.0.52",
     "aws-sdk": "^2.200.1",
     "chai": "3.5.0",
     "chai-as-promised": "6.0.0",
+    "debug": "^3.1.0",
     "dynamo-local": "0.0.4",
     "dynamo-types": "^2.5.0",
     "faker": "^4.1.0",
@@ -38,7 +40,9 @@
   },
   "peerDependencies": {
     "dynamo-types": ">=2.5.0",
-    "aws-sdk": ">=2.100.0"
+    "aws-sdk": ">=2.100.0",
+    "debug": ">=3.0.0",
+    "@types/debug": ">=0.0.30"
   },
   "dependencies": {}
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,8 +1,6 @@
 import { Codec, Metadata, Table } from "dynamo-types";
 
-// Helpers
 import { DynamoDBStreamEvent } from "./dynamodb_stream_event";
-import { LambdaContext } from "./lambda_context";
 
 export interface InsertStreamEvent<T> {
   type: "INSERT";
@@ -57,25 +55,6 @@ export function parseEvent<T extends Table>(
   });
 }
 
-function valueFilter<T>(array: Array<T | undefined | null>) {
-  const res: T[] = [];
-  array.forEach((item) => {
-    if (item !== undefined && item !== null) {
-      res.push(item);
-    }
-  });
-  return res;
-}
-
-export function createLambdaHandler(handler: (event: DynamoDBStreamEvent) => Promise<void>) {
-  return async (event: DynamoDBStreamEvent, context: LambdaContext) => {
-    handler(event).then(
-      () => context.succeed(),
-      (error) => context.fail(error),
-    );
-  };
-}
-
 export type HandlerDefinition<T> = {
   eventType: "INSERT",
   name: string,
@@ -105,76 +84,3 @@ export type HandlerDefinition<T> = {
   name: string,
   handler: (events: Array<StreamEvent<T>>) => Promise<void>,
 };
-
-/**
- *
- * @param tableClass DynamoTypes Class
- * @param strategy handler Execution strategy. Map execute all handlers once, Series excute handlers one by one
- * @param handlers
- */
-export function createTableHandler<T extends Table>(
-  tableClass: ITable<T>,
-  strategy: "Map" | "Series" = "Series",
-  handlers: Array<HandlerDefinition<T>>,
-  catchError: (
-    handlerDefinition: HandlerDefinition<T>,
-    events: Array<StreamEvent<T>>,
-    error: Error
-  ) => Promise<void> | void
-) {
-  return async (event: DynamoDBStreamEvent): Promise<void> => {
-    const records = parseEvent(tableClass, event);
-
-    switch (strategy) {
-      case "Series":
-        for (const handler of handlers) {
-          try {
-            await executeHandler(handler, records);
-          } catch (error) {
-            catchError(handler, records, error);
-          }
-        }
-        return;
-      case "Map":
-        await Promise.all(handlers.map(async (handler) => {
-          try {
-            await executeHandler(handler, records);
-          } catch (error) {
-            catchError(handler, records, error);
-          }
-        }));
-        return;
-    }
-  };
-}
-
-function executeHandler<T>(handlerDefinition: HandlerDefinition<T>, records: Array<StreamEvent<T>>) {
-  switch (handlerDefinition.eventType) {
-    case "INSERT":
-      return handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "INSERT" ? record : null)),
-      );
-    case "MODIFY":
-      return handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "MODIFY" ? record : null)),
-      );
-    case "REMOVE":
-      return handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "REMOVE" ? record : null)),
-      );
-    case "INSERT, MODIFY":
-      return handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "INSERT" || record.type === "MODIFY" ? record : null)),
-      );
-    case "MODIFY, REMOVE":
-      return handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "MODIFY" || record.type === "REMOVE" ? record : null)),
-      );
-    case "INSERT, REMOVE":
-      return handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "INSERT" || record.type === "REMOVE" ? record : null)),
-      );
-    case "ALL":
-      return handlerDefinition.handler(valueFilter(records));
-  }
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./dynamodb_stream_event";
-export * from "./lambda_context";
 export * from "./handler";
+export * from "./lambda_context";
+export * from "./stream_handler";
+export * from "./table_handler";

--- a/src/stream_handler.ts
+++ b/src/stream_handler.ts
@@ -1,0 +1,79 @@
+import * as debug from "debug";
+
+import { DynamoDBStreamEvent } from "./dynamodb_stream_event";
+import { LambdaContext } from "./lambda_context";
+import { TableHandler } from "./table_handler";
+
+const logger = debug("dynamo-types-stream:StreamHandler");
+
+export class StreamHandler {
+  public readonly tableHandlerMap: Map<string, TableHandler<any>>;
+  constructor(
+    tableHandlers: Array<TableHandler<any>>
+  ) {
+    this.tableHandlerMap = new Map();
+
+    tableHandlers.forEach(handler => {
+      const tableName = handler.tableClass.metadata.name;
+      if (this.tableHandlerMap.has(tableName)) {
+        throw new Error(`You can't put more than one handler for given table: ${tableName}`);
+      }
+
+      this.tableHandlerMap.set(tableName, handler);
+    });
+  }
+
+  public get handler() {
+    return async (event: DynamoDBStreamEvent) => {
+      if (event.Records.length > 0) {
+        // Even though each records has own eventSourceARN,
+        // one event only has one eventSoruceARN.
+        // Thus, select "one" event source arn.
+        const sourceARN = event.Records[0].eventSourceARN;
+        logger("handler: sourceARN - %s", sourceARN);
+        const streamMetadata = parseDynamoDBStreamARN(sourceARN);
+        if (!streamMetadata) {
+          throw new Error(`Invalid Source Arn : ${sourceARN}`);
+        }
+
+        const handler = this.tableHandlerMap.get(streamMetadata.tableName);
+        if (handler) {
+          logger("handler: start table handler: %s", streamMetadata.tableName);
+          handler.handler(event);
+        } else {
+          logger("handler: sourceARN - %s, There is no table handler for arn", sourceARN);
+        }
+      }
+    };
+  }
+
+  public get lambdaHandler() {
+    return async (event: DynamoDBStreamEvent, context: LambdaContext) => {
+      this.handler(event).then(
+        () => context.succeed(),
+        (error) => context.fail(error),
+      );
+    };
+  }
+}
+
+/**
+ *
+ * @param arn
+ * @returns - null means invalid arn
+ */
+
+// arn:aws:dynamodb:us-east-1:921281748045:table/qna_production_questions/stream/2017-12-22T02:02:25.496
+export function parseDynamoDBStreamARN(arn: string) {
+  const arnRegex = /arn:aws:dynamodb:(\w+-\w+-\d):(\d+):table\/(\w+)\/stream\/(\S+)/;
+  const match = arn.match(arnRegex);
+  if (match && match.length === 5) {
+    return {
+      region: match[1],
+      awsAccountId: match[2],
+      tableName: match[3],
+    };
+  } else {
+    return null;
+  }
+}

--- a/src/stream_handler.ts
+++ b/src/stream_handler.ts
@@ -39,7 +39,7 @@ export class StreamHandler {
         const handler = this.tableHandlerMap.get(streamMetadata.tableName);
         if (handler) {
           logger("handler: start table handler: %s", streamMetadata.tableName);
-          handler.handler(event);
+          await handler.handler(event);
         } else {
           logger("handler: sourceARN - %s, There is no table handler for arn", sourceARN);
         }
@@ -49,7 +49,7 @@ export class StreamHandler {
 
   public get lambdaHandler() {
     return async (event: DynamoDBStreamEvent, context: LambdaContext) => {
-      this.handler(event).then(
+      await this.handler(event).then(
         () => context.succeed(),
         (error) => context.fail(error),
       );

--- a/src/table_handler.ts
+++ b/src/table_handler.ts
@@ -52,34 +52,34 @@ export class TableHandler<T extends Table> {
   }
 }
 
-function executeHandler<T>(handlerDefinition: HandlerDefinition<T>, records: Array<StreamEvent<T>>) {
+async function executeHandler<T>(handlerDefinition: HandlerDefinition<T>, records: Array<StreamEvent<T>>) {
   switch (handlerDefinition.eventType) {
     case "INSERT":
-      return handlerDefinition.handler(
+      return await handlerDefinition.handler(
         valueFilter(records.map((record) => record.type === "INSERT" ? record : null)),
       );
     case "MODIFY":
-      return handlerDefinition.handler(
+      return await handlerDefinition.handler(
         valueFilter(records.map((record) => record.type === "MODIFY" ? record : null)),
       );
     case "REMOVE":
-      return handlerDefinition.handler(
+      return await handlerDefinition.handler(
         valueFilter(records.map((record) => record.type === "REMOVE" ? record : null)),
       );
     case "INSERT, MODIFY":
-      return handlerDefinition.handler(
+      return await handlerDefinition.handler(
         valueFilter(records.map((record) => record.type === "INSERT" || record.type === "MODIFY" ? record : null)),
       );
     case "MODIFY, REMOVE":
-      return handlerDefinition.handler(
+      return await handlerDefinition.handler(
         valueFilter(records.map((record) => record.type === "MODIFY" || record.type === "REMOVE" ? record : null)),
       );
     case "INSERT, REMOVE":
-      return handlerDefinition.handler(
+      return await handlerDefinition.handler(
         valueFilter(records.map((record) => record.type === "INSERT" || record.type === "REMOVE" ? record : null)),
       );
     case "ALL":
-      return handlerDefinition.handler(valueFilter(records));
+      return await handlerDefinition.handler(valueFilter(records));
   }
 }
 

--- a/src/table_handler.ts
+++ b/src/table_handler.ts
@@ -1,0 +1,94 @@
+import { Table } from "dynamo-types";
+
+import {
+  HandlerDefinition,
+  ITable,
+  parseEvent,
+  StreamEvent,
+} from "./handler";
+
+import { DynamoDBStreamEvent } from "./dynamodb_stream_event";
+
+export class TableHandler<T extends Table> {
+  constructor(
+    public readonly tableClass: ITable<T>,
+    private readonly strategy: "Map" | "Series" = "Series",
+    private readonly handlers: Array<HandlerDefinition<T>>,
+    private readonly catchError: (
+      handlerDefinition: HandlerDefinition<T>,
+      events: Array<StreamEvent<T>>,
+      error: Error
+    ) => Promise<void> | void
+  ) {
+  }
+
+  public get handler() {
+    return async (event: DynamoDBStreamEvent): Promise<void> => {
+      const records = parseEvent(this.tableClass, event);
+
+      switch (this.strategy) {
+        case "Series":
+          for (const handler of this.handlers) {
+            try {
+              await executeHandler(handler, records);
+            } catch (error) {
+              this.catchError(handler, records, error);
+            }
+          }
+          break;
+        case "Map":
+          await Promise.all(
+            this.handlers.map(async (handler) => {
+              try {
+                await executeHandler(handler, records);
+              } catch (error) {
+                this.catchError(handler, records, error);
+              }
+            })
+          );
+          break;
+      }
+    };
+  }
+}
+
+function executeHandler<T>(handlerDefinition: HandlerDefinition<T>, records: Array<StreamEvent<T>>) {
+  switch (handlerDefinition.eventType) {
+    case "INSERT":
+      return handlerDefinition.handler(
+        valueFilter(records.map((record) => record.type === "INSERT" ? record : null)),
+      );
+    case "MODIFY":
+      return handlerDefinition.handler(
+        valueFilter(records.map((record) => record.type === "MODIFY" ? record : null)),
+      );
+    case "REMOVE":
+      return handlerDefinition.handler(
+        valueFilter(records.map((record) => record.type === "REMOVE" ? record : null)),
+      );
+    case "INSERT, MODIFY":
+      return handlerDefinition.handler(
+        valueFilter(records.map((record) => record.type === "INSERT" || record.type === "MODIFY" ? record : null)),
+      );
+    case "MODIFY, REMOVE":
+      return handlerDefinition.handler(
+        valueFilter(records.map((record) => record.type === "MODIFY" || record.type === "REMOVE" ? record : null)),
+      );
+    case "INSERT, REMOVE":
+      return handlerDefinition.handler(
+        valueFilter(records.map((record) => record.type === "INSERT" || record.type === "REMOVE" ? record : null)),
+      );
+    case "ALL":
+      return handlerDefinition.handler(valueFilter(records));
+  }
+}
+
+function valueFilter<T>(array: Array<T | undefined | null>) {
+  const res: T[] = [];
+  array.forEach((item) => {
+    if (item !== undefined && item !== null) {
+      res.push(item);
+    }
+  });
+  return res;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,14 @@
         "noImplicitAny": true,
         "sourceMap": true,
         "outDir": "dst",
-        "emitDecoratorMetadata": true,
+        "strictNullChecks": true,
         "experimentalDecorators": true,
-        "strictNullChecks": true
+        "emitDecoratorMetadata": true,
+        "noUnusedLocals": true,
+        "lib": [
+            "esnext",
+            "esnext.asynciterable"
+        ]
     },
     "exclude": [
         "**/__test__/"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -5,9 +5,14 @@
         "noImplicitAny": true,
         "sourceMap": true,
         "outDir": "dst",
-        "emitDecoratorMetadata": true,
+        "strictNullChecks": true,
         "experimentalDecorators": true,
-        "strictNullChecks": true
+        "emitDecoratorMetadata": true,
+        "noUnusedLocals": true,
+        "lib": [
+            "esnext",
+            "esnext.asynciterable"
+        ]
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
Major Changes

1) createTableHandler -> new TableHandler()
  - Thus, TableHandler class is not "function". 
  - (new TableHandler()).handler === createTableHandler()
2) StreamHandler Class Added
  - "StreamHandler" is consists of "multiple table handlers"
  - For example, if you have Table A and Table B, if you want to handle those 2 tables dynamoDB stream on single lambda function.
  - Then, you don't need to map dynamoDB ARN or anything anymore.
```
  import { A, B } from "../models";
 
  export const handler = new StreamHandler([
     new TableHandler(A ..., ...., ...)
     new TableHandler(B ...,. ..., ...)
  ]).lambdaHandler
```

  - So responsibility for StreamHandler is 
      a) Select which tableHandler to use depends on eventSourceARN of payload
      b) Promise handler -> Lambda Handler (using context.done())

  - If you already have your own Promise Handler -> Lambda Handler, (or if you have some custom code to run first
```
  import { A, B } from "../models";
 
  export const handler = async function(event, context) {
     // Other things..
     
     await new StreamHandler([
        new TableHandler(A ..., ...., ...)
        new TableHandler(B ...,. ..., ...)
     ]).handler(event);
     
     // Other things...
  }

```
