### PR TITLE
v1.0.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-types-stream",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-types-stream",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.1",
   "description": "DynamoDB Stream Framework",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/__test__/index_spec.ts
+++ b/src/__test__/index_spec.ts
@@ -45,17 +45,25 @@ import { StreamHandler, TableHandler } from "../index";
 
 describe("E2E", () => {
   let streamHandler: StreamHandler;
-  let userHandlerCalled: boolean;
+  let userInsertHandlerCalled: boolean;
+  let userRemoveHandlerCalled: boolean;
   let cardHandlerCalled: boolean;
   beforeEach(() => {
-    userHandlerCalled = false;
+    userInsertHandlerCalled = false;
+    userRemoveHandlerCalled = false;
     const userHandler = new TableHandler(
       User, "Series",
       [{
         eventType: "INSERT",
         name: "Test Handler",
         async handler(events) {
-          userHandlerCalled = true;
+          userInsertHandlerCalled = true;
+        },
+      }, {
+        eventType: "REMOVE",
+        name: "Test Handler",
+        async handler(events) {
+          userRemoveHandlerCalled = true;
         },
       }],
       async (handlerDef, events, error) => {
@@ -100,7 +108,10 @@ describe("E2E", () => {
       } as any]
     });
 
-    expect(userHandlerCalled).to.be.eq(true);
+    expect(userInsertHandlerCalled).to.be.eq(true);
+    // Since there is only "Insert" event, this should not be called
+    expect(userRemoveHandlerCalled).to.be.eq(false);
+
     expect(cardHandlerCalled).to.be.eq(false);
   });
 });

--- a/src/table_handler.ts
+++ b/src/table_handler.ts
@@ -53,33 +53,51 @@ export class TableHandler<T extends Table> {
 }
 
 async function executeHandler<T>(handlerDefinition: HandlerDefinition<T>, records: Array<StreamEvent<T>>) {
-  switch (handlerDefinition.eventType) {
-    case "INSERT":
-      return await handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "INSERT" ? record : null)),
-      );
-    case "MODIFY":
-      return await handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "MODIFY" ? record : null)),
-      );
-    case "REMOVE":
-      return await handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "REMOVE" ? record : null)),
-      );
-    case "INSERT, MODIFY":
-      return await handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "INSERT" || record.type === "MODIFY" ? record : null)),
-      );
-    case "MODIFY, REMOVE":
-      return await handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "MODIFY" || record.type === "REMOVE" ? record : null)),
-      );
-    case "INSERT, REMOVE":
-      return await handlerDefinition.handler(
-        valueFilter(records.map((record) => record.type === "INSERT" || record.type === "REMOVE" ? record : null)),
-      );
-    case "ALL":
-      return await handlerDefinition.handler(valueFilter(records));
+  const { handler, filteredRecords } = (() => {
+    switch (handlerDefinition.eventType) {
+      case "INSERT":
+        return {
+          handler: handlerDefinition.handler,
+          filteredRecords: valueFilter(records.map((record) => record.type === "INSERT" ? record : null))
+        };
+      case "MODIFY":
+        return {
+          handler: handlerDefinition.handler,
+          filteredRecords: valueFilter(records.map((record) => record.type === "MODIFY" ? record : null)),
+        };
+      case "REMOVE":
+        return {
+          handler: handlerDefinition.handler,
+          filteredRecords: valueFilter(records.map((record) => record.type === "REMOVE" ? record : null)),
+        };
+      case "INSERT, MODIFY":
+        return {
+          handler: handlerDefinition.handler,
+          filteredRecords: valueFilter(
+            records.map((record) => record.type === "INSERT" || record.type === "MODIFY" ? record : null)),
+        };
+      case "MODIFY, REMOVE":
+        return {
+          handler: handlerDefinition.handler,
+          filteredRecords: valueFilter(
+            records.map((record) => record.type === "MODIFY" || record.type === "REMOVE" ? record : null)),
+        };
+      case "INSERT, REMOVE":
+        return {
+          handler: handlerDefinition.handler,
+          filteredRecords: valueFilter(
+            records.map((record) => record.type === "INSERT" || record.type === "REMOVE" ? record : null)),
+        };
+      case "ALL":
+        return {
+          handler: handlerDefinition.handler,
+          filteredRecords: valueFilter(records),
+        };
+    }
+  })();
+
+  if (filteredRecords.length > 0) {
+    await handler(filteredRecords);
   }
 }
 


### PR DESCRIPTION
Prevent redundant handler invocation. Such as you've created "Insert" handler, and there is only "remove" event on this batch

Currently, this would invoke ```InsertHandler([])``` which is surely meaningless.
which this change, it won't invoke handler when there isn't any events that match filter
